### PR TITLE
Modificación de un favor: Capacidad para remover foto actual

### DIFF
--- a/IS2G28/src/favors/edit.css
+++ b/IS2G28/src/favors/edit.css
@@ -1,0 +1,18 @@
+/* 
+  Created on : 14/07/2017, 00:07:31
+  Author     : juan
+  Description: Hoja de estilos correspondiente a la pantalla de edición de favor.    
+*/
+
+img.favor-photo {
+  width: 50px;
+  height: 50px;
+  float: left;
+  margin-right: 10px;
+}
+
+p.help-block {
+  margin: 3px 0px 0px;
+  font-size: 13px;
+}
+

--- a/IS2G28/src/favors/edit.css
+++ b/IS2G28/src/favors/edit.css
@@ -11,8 +11,14 @@ img.favor-photo {
   margin-right: 10px;
 }
 
-p.help-block {
+.form-group p.help-block {
   margin: 3px 0px 0px;
   font-size: 13px;
+  color: #737373; 
+}
+
+.has-error .checkbox {
+  color: #333;
+  padding-top: 0px;
 }
 

--- a/IS2G28/src/favors/edit.js
+++ b/IS2G28/src/favors/edit.js
@@ -1,0 +1,26 @@
+$(document).ready(function() {
+  
+  var favorPhotoControl = $('#favor_photo');
+      
+  /**
+   * Manejador del click en el checkbox para remover foto del favor 
+   */
+  $('#favor_photo_deleted_flag').click(function() {        
+    if ($(this).prop('checked')) {
+      // Si el checkbox está marcado,
+      // Resetear e inhabilitar campo para subir nueva foto          
+      resetInputFileElement(favorPhotoControl);
+      favorPhotoControl.prop('disabled', true);                    
+    } else {
+      // Habilitar campo para subir nueva foto
+      favorPhotoControl.prop('disabled', false);          
+    }        
+  });
+
+  function resetInputFileElement(element) {
+    element.wrap('<form>').closest('form').get(0).reset();
+    element.unwrap();
+  };
+  
+})();
+

--- a/IS2G28/src/favors/form-edition.tpl.php
+++ b/IS2G28/src/favors/form-edition.tpl.php
@@ -4,14 +4,7 @@
     <title>Una Gauchada - Edici&oacute;n de favor</title>
     <?php require '../common/common_headers.php'; ?>    
     <link type="text/css" rel="stylesheet" href="new.css">
-    <style type="text/css">
-      img.favor-photo {
-        width: 50px;
-        height: 50px;
-        float: left;
-        margin-right: 10px;
-      }
-    </style>
+    <link type="text/css" rel="stylesheet" href="edit.css">    
     <script type="text/javascript" src="new.js"></script>
   </head>
   <body>
@@ -63,14 +56,24 @@
                     <?php if ($favor->getPhoto()): ?>
                       <img src="../uploads/<?php echo $favor->getPhoto() ?>" alt="Foto del favor" class="img-circle favor-photo">                    
                     <?php endif; ?>
-                    <input type="file" id="favor_photo" name="favor_photo">
-                    El tamaño m&aacute;ximo de la imagen es 1024 kB
+                    <input type="file" id="favor_photo" name="favor_photo">                   
+                    <p class="help-block">El tamaño m&aacute;ximo de la imagen es 1024 kB.</p>
                     <!-- Contenedor del mensaje de error -->
                     <span class="error help-block <?php echo isset($errors['photo'])?'shown':'hidden' ?>">
                       <?php echo isset($errors['photo'])?$errors['photo']:'' ?>
-                    </span>                    
-                  </div>
-              </div>
+                    </span>                                       
+                    <?php if($favor->getPhoto()): ?>
+                      <!-- Checkbox para poder remover foto del favor -->
+                      <div class="checkbox">
+                        <label>
+                          <input type="checkbox" id="favor_photo_deleted_flag">
+                          Quiero remover foto actual del favor. 
+                        </label>
+                      </div>
+                    <?php endif; ?>
+                  </div>                  
+              </div>              
+              
               <!-- Ciudad donde se debe realizar favor -->
               <div class="form-group <?php echo isset($errors['city'])?'has-error':'' ?>">
                   <label for="favor_city" class="col-sm-3 control-label">Ciudad</label>

--- a/IS2G28/src/favors/form-edition.tpl.php
+++ b/IS2G28/src/favors/form-edition.tpl.php
@@ -6,6 +6,7 @@
     <link type="text/css" rel="stylesheet" href="new.css">
     <link type="text/css" rel="stylesheet" href="edit.css">    
     <script type="text/javascript" src="new.js"></script>
+    <script type="text/javascript" src="edit.js"></script>
   </head>
   <body>
     <!-- Contenedor principal, requerido por Bootstrap -->
@@ -112,6 +113,6 @@
           </form>
         </div>                                
       </div>
-    </div>    
+    </div>         
   </body>    
 </html>

--- a/IS2G28/src/favors/form-edition.tpl.php
+++ b/IS2G28/src/favors/form-edition.tpl.php
@@ -67,7 +67,7 @@
                       <!-- Checkbox para poder remover foto del favor -->
                       <div class="checkbox">
                         <label>
-                          <input type="checkbox" id="favor_photo_deleted_flag">
+                          <input type="checkbox" id="favor_photo_deleted_flag" name="favor_photo_deleted_flag">
                           Quiero remover foto actual del favor. 
                         </label>
                       </div>

--- a/IS2G28/src/model/Favor.php
+++ b/IS2G28/src/model/Favor.php
@@ -33,7 +33,7 @@ class Favor
   protected $description;
   
   /**
-   * @Column(type="string")
+   * @Column(type="string", nullable=true)
    * @var string 
    */
   protected $photo;


### PR DESCRIPTION
Se agregó a la modificación de un favor la posibilidad de remover la foto del mismo sin necesidad de subir una nueva foto para el favor. Como consecuencia de este cambio, se modificó el esquema de la base de datos para admitir valores nulos en el campo correspondiente a la foto del favor. Por tanto, **es necesario actualizar el esquema de la base de datos mediante orm:schema-tool:update**.